### PR TITLE
refactor(core): add Transform4x4::transform_point, use in unproject

### DIFF
--- a/src/bridge/unproject.rs
+++ b/src/bridge/unproject.rs
@@ -30,13 +30,7 @@ pub fn unproject(
     let zc = d;
 
     // Step 4 — apply the 4×4 pose transform (row-major).
-    // P_world = pose · [xc, yc, zc, 1]ᵀ
-    let m = &pose.matrix;
-    let xw = m[0] as f64 * xc + m[1] as f64 * yc + m[2]  as f64 * zc + m[3]  as f64;
-    let yw = m[4] as f64 * xc + m[5] as f64 * yc + m[6]  as f64 * zc + m[7]  as f64;
-    let zw = m[8] as f64 * xc + m[9] as f64 * yc + m[10] as f64 * zc + m[11] as f64;
-
-    Point3D { x: xw as f32, y: yw as f32, z: zw as f32 }
+    pose.transform_point(xc, yc, zc)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,19 @@ impl Transform4x4 {
         ];
         Self { matrix: m }
     }
+
+    /// Apply this transform to a camera-space point, returning a world-space [`Point3D`].
+    ///
+    /// Computes `P_world = self · [xc, yc, zc, 1]ᵀ` using the top three rows of the
+    /// row-major 4×4 matrix (the homogeneous bottom row is not needed for affine transforms).
+    pub fn transform_point(&self, xc: f64, yc: f64, zc: f64) -> Point3D {
+        let m = &self.matrix;
+        Point3D {
+            x: (m[0] as f64 * xc + m[1] as f64 * yc + m[2]  as f64 * zc + m[3]  as f64) as f32,
+            y: (m[4] as f64 * xc + m[5] as f64 * yc + m[6]  as f64 * zc + m[7]  as f64) as f32,
+            z: (m[8] as f64 * xc + m[9] as f64 * yc + m[10] as f64 * zc + m[11] as f64) as f32,
+        }
+    }
 }
 
 /// 3D world-space point.
@@ -116,6 +129,32 @@ mod tests {
     fn bbox_center_degenerate_zero_size() {
         let bbox = BBox2D { u0: 5.0, v0: 7.0, u1: 5.0, v1: 7.0 };
         assert_eq!(bbox.center(), (5.0, 7.0));
+    }
+
+    // --- Transform4x4::transform_point ---
+
+    #[test]
+    fn transform_point_identity_returns_input() {
+        let p = Transform4x4::identity().transform_point(1.0, 2.0, 3.0);
+        assert!((p.x - 1.0).abs() < 1e-6);
+        assert!((p.y - 2.0).abs() < 1e-6);
+        assert!((p.z - 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn transform_point_translation_offsets_correctly() {
+        // Translation-only matrix: identity rotation, tx=10, ty=20, tz=30
+        #[rustfmt::skip]
+        let t = Transform4x4 { matrix: [
+            1.0, 0.0, 0.0, 10.0,
+            0.0, 1.0, 0.0, 20.0,
+            0.0, 0.0, 1.0, 30.0,
+            0.0, 0.0, 0.0,  1.0,
+        ]};
+        let p = t.transform_point(1.0, 2.0, 3.0);
+        assert!((p.x - 11.0).abs() < 1e-5);
+        assert!((p.y - 22.0).abs() < 1e-5);
+        assert!((p.z - 33.0).abs() < 1e-5);
     }
 
     // --- Transform4x4::identity ---


### PR DESCRIPTION
## Summary
- Adds `Transform4x4::transform_point(xc, yc, zc) -> Point3D` to `src/lib.rs`
- Replaces 4 lines of inline matrix math in `unproject.rs` with a single call
- 2 new unit tests: identity returns input unchanged; translation-only matrix offsets correctly
- 39/39 tests pass

## Why
M4 (`bridge/sync.rs`) will need to apply pose transforms too. Without this method the inline math gets copy-pasted. Extracting it now keeps the logic in one place and testable in isolation.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)