### PR TITLE
fix(buffer): use lower-bound predicate in partition_point

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -65,7 +65,9 @@ impl PoseBuffer {
 
         let mut best: Option<(u64, Transform4x4)> = None;
         for seg in [seg_a, seg_b] {
-            let idx = seg.partition_point(|e| e.ts_us <= capture_ts_us);
+            // lower_bound: idx is the first entry with ts_us >= capture_ts_us.
+            // Exact match lands at idx; nearest-before lands at idx-1.
+            let idx = seg.partition_point(|e| e.ts_us < capture_ts_us);
             for &i in &[idx.wrapping_sub(1), idx] {
                 if let Some(e) = seg.get(i) {
                     let delta = e.ts_us.abs_diff(capture_ts_us);


### PR DESCRIPTION
## Summary

- Changes `e.ts_us <= capture_ts_us` → `e.ts_us < capture_ts_us` in both `partition_point` calls inside `pose_at`
- Adopts the standard lower-bound idiom: `idx` is now the first entry with `ts_us >= capture_ts_us`, so an exact match lands directly at `idx` rather than `idx-1`
- Correctness is unchanged — both neighbouring candidates are still evaluated and the closest within tolerance wins
- Raised by static analysis (AGENTS.md finding)

## Test plan

- [ ] All existing `PoseBuffer` tests pass (exact match, tolerance boundary, ring overwrite, closest-of-two)
- [ ] CI green (fmt, clippy, test, deny)

🤖 Generated with [Claude Code](https://claude.com/claude-code)