### PR TITLE
fix(ingress): correct blank_jpeg byte-count in doc comment

### DIFF
--- a/src/ingress/mock.rs
+++ b/src/ingress/mock.rs
@@ -47,7 +47,7 @@ impl MockSource {
         Transform4x4 { matrix }
     }
 
-    /// Minimal valid 1×1 white JPEG (24 bytes).
+    /// Minimal valid 1×1 white JPEG (208 bytes).
     fn blank_jpeg() -> Vec<u8> {
         // A 1x1 white pixel JPEG generated offline and embedded as bytes.
         vec![


### PR DESCRIPTION
## Summary

- Fixes wrong byte count in the `blank_jpeg` doc comment: was `24`, actual blob is `208` bytes
- Identified from the valid part of AI finding in #24 (closed without merge because the other finding — `Result` return on a test-only constructor — was not appropriate)

## Test plan

- [ ] CI green (no logic change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)