### PR TITLE
fix(buffer): debug_assert monotonic timestamps in PoseBuffer::push

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -31,7 +31,24 @@ impl PoseBuffer {
     }
 
     /// Insert a pose with its capture timestamp.
+    ///
+    /// # Panics (debug builds only)
+    /// Asserts that `ts_us` is strictly greater than the previously pushed
+    /// timestamp. The binary search in [`Self::pose_at`] relies on
+    /// monotonically increasing timestamps; out-of-order pushes would cause
+    /// silent incorrect lookups in release builds.
     pub fn push(&mut self, ts_us: u64, pose: Transform4x4) {
+        if self.len > 0 {
+            // The last-pushed entry sits at (head + len - 1) % capacity,
+            // which is correct for both the growing phase and the ring phase.
+            let last_idx = (self.head + self.len - 1) % self.capacity;
+            debug_assert!(
+                ts_us > self.entries[last_idx].ts_us,
+                "PoseBuffer::push: timestamps must be strictly increasing \
+                 (got {ts_us}, last was {})",
+                self.entries[last_idx].ts_us,
+            );
+        }
         let entry = Entry { ts_us, pose };
         if self.len < self.capacity {
             self.entries.push(entry);
@@ -156,6 +173,24 @@ mod tests {
         buf.push(2_000_000, identity());
         assert!(buf.pose_at(1_000_000).is_none(), "overwritten entry must be gone");
         assert!(buf.pose_at(2_000_000).is_some());
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "timestamps must be strictly increasing")]
+    fn out_of_order_push_panics_in_debug() {
+        let mut buf = PoseBuffer::new(16, 200_000);
+        buf.push(2_000_000, identity());
+        buf.push(1_000_000, identity()); // older timestamp — must panic
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "timestamps must be strictly increasing")]
+    fn equal_timestamp_push_panics_in_debug() {
+        let mut buf = PoseBuffer::new(16, 200_000);
+        buf.push(1_000_000, identity());
+        buf.push(1_000_000, identity()); // same timestamp — must panic
     }
 
     #[test]


### PR DESCRIPTION
Closes #26

## Summary

Adds a `debug_assert!` in `PoseBuffer::push` that fires in debug/test builds when an out-of-order or equal-timestamp entry is pushed. The binary search in `pose_at` silently returns wrong results if this invariant is violated; the assert catches platform SDK misbehaviour immediately in development.

**Key detail:** the last-pushed entry is at index `(head + len - 1) % capacity`. The naive `entries.last()` approach suggested in the issue is wrong after the ring wraps around — it reads the wrong slot.

**Two new `#[should_panic]` tests** (gated on `#[cfg(debug_assertions)]`):
- `out_of_order_push_panics_in_debug` — older timestamp after a newer one
- `equal_timestamp_push_panics_in_debug` — duplicate timestamp

Zero cost in release builds (`debug_assert!` compiles away).

## Test plan

- [ ] `cargo test` — 41 tests pass (including the two new should_panic tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)