### PR TITLE
design(types): document Point3D f32 precision — keep f32, require local frame

### DIFF
--- a/docs/math.md
+++ b/docs/math.md
@@ -292,7 +292,24 @@ When implementing and debugging unprojection, these are typical values for a veh
 | `fx`, `fy` | 800–1500 pixels (typical automotive camera) |
 | `d` (depth) | 0.5–5.0 m |
 | `Xc`, `Yc` | ±1.5 m at 2 m depth |
-| `Xw`, `Yw`, `Zw` | site-scale metres, depends on map origin |
+| `Xw`, `Yw`, `Zw` | site-scale metres, local frame from map origin |
 | Point cloud size | 50K–500K points per sweep |
 | `resolution_m` (height map) | 0.005–0.02 m (5–20 mm per cell) |
 | Deviation threshold | 0.005–0.01 m (5–10 mm) |
+
+## Coordinate Precision and `f32`
+
+`Point3D` stores coordinates as `f32`. `f32` has machine epsilon ≈ 1.2 × 10⁻⁷, giving ~7 significant decimal digits.
+
+**Requirement:** all `Point3D` values must be expressed in a **local coordinate frame** — i.e. as offsets from a nearby origin such as the SLAM map start position, not as absolute geodetic coordinates (UTM, WGS-84).
+
+| Max coordinate magnitude | `f32` representable step | Adequate for 1 cm target? |
+|---|---|---|
+| 100 m (large building) | ~0.012 mm | Yes |
+| 1 km (city block) | ~0.12 mm | Yes |
+| 10 km | ~1.2 mm | Yes |
+| 100 km (UTM scale) | ~12 mm | **No** |
+
+The system targets 1 cm accuracy over construction-site distances (≤ 1 km). `f32` is sufficient. `CameraIntrinsics` uses `f64` and `transform_point` promotes to `f64` during the matrix multiply, so projection arithmetic is double-precision; only the final stored `Point3D` result is rounded to `f32`.
+
+If absolute geodetic coordinates are required in future, convert to a local tangent-plane frame (e.g. ENU centred on the site datum) before constructing `Point3D` values.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,31 @@ impl Transform4x4 {
     }
 }
 
-/// 3D world-space point.
+/// 3D world-space point, expressed in a **local coordinate frame**.
+///
+/// # Coordinate frame requirement
+///
+/// All coordinates must be local offsets from a nearby origin (e.g. the SLAM
+/// map origin or the scanner start position), **not** absolute geodetic values
+/// such as UTM easting/northing. Keeping coordinates local ensures that `f32`
+/// precision is adequate.
+///
+/// # Precision analysis
+///
+/// `f32` provides ~7 significant decimal digits (machine epsilon ≈ 1.2 × 10⁻⁷).
+/// At a coordinate magnitude of `M` metres, the representable step size is
+/// approximately `M × 1.2 × 10⁻⁷` metres:
+///
+/// | Max coordinate magnitude | Representable step | Adequate for 1 cm target? |
+/// |---|---|---|
+/// | 100 m (large building) | ~0.012 mm | Yes |
+/// | 1 km (city block) | ~0.12 mm | Yes |
+/// | 10 km | ~1.2 mm | Yes |
+/// | 100 km (UTM scale) | ~12 mm | **No** |
+///
+/// The system targets 1 cm accuracy over construction-site distances (≤ 1 km).
+/// `f32` is sufficient for this range. If absolute geodetic coordinates are
+/// ever required, convert to a local tangent-plane frame first.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct Point3D {
     pub x: f32,


### PR DESCRIPTION
## Decision

Keep `Point3D` as `f32`. Closes #40.

## Rationale

| Option | Verdict |
|---|---|
| Keep `f32` + local frame | **Chosen** |
| Switch to `f64` | Rejected — doubles memory, no practical gain at ≤1 km |
| Generic `Point3D<T>` | Rejected — API complexity for no current use case |

`f32` machine epsilon ≈ 1.2 × 10⁻⁷ gives a representable step of ~0.12 mm at 1 km — well within the 1 cm accuracy target. `CameraIntrinsics` already uses `f64` and `transform_point` promotes to `f64` during the matrix multiply; only the final stored `Point3D` is rounded to `f32`.

The one scenario where `f32` is insufficient (absolute UTM coordinates at 100 km scale) is outside the construction-inspection use case. If needed in future, the conversion path is ENU local tangent-plane from a site datum.

## Changes

- `src/lib.rs` — extended `Point3D` doc comment with precision table and local-frame requirement
- `docs/math.md` — added "Coordinate Precision and `f32`" section with the same table

## Test plan

- [x] `cargo test` — all pass
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Reviewer confirms precision table values are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)