### PR TITLE
fix(ci): use cargo metadata to read version, POSIX sed to write it

### DIFF
--- a/.github/workflows/auto-version-tag.yml
+++ b/.github/workflows/auto-version-tag.yml
@@ -66,7 +66,7 @@ jobs:
         if: ${{ steps.guard.outputs.is_release_commit != 'true' }}
         run: |
           LAST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -n1 || true)
-          CURRENT_VERSION=$(grep -m1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | python3 -c "import json,sys; print(json.load(sys.stdin)['packages'][0]['version'])")
 
           if [[ -z "$LAST_TAG" ]]; then
             echo "No previous tag found. Using current version: $CURRENT_VERSION"
@@ -119,7 +119,7 @@ jobs:
       - name: Update version in Cargo.toml
         if: ${{ steps.guard.outputs.is_release_commit != 'true' && steps.tag_check.outputs.tag_exists != 'true' && steps.semver.outputs.next_version != steps.semver.outputs.current_version }}
         run: |
-          sed -i "s/^version = \"[0-9]*\.[0-9]*\.[0-9]*\"/version = \"${{ steps.semver.outputs.next_version }}\"/" Cargo.toml
+          sed -i -E 's/^(version[[:space:]]*=[[:space:]]*")[0-9]+\.[0-9]+\.[0-9]+/\1${{ steps.semver.outputs.next_version }}/' Cargo.toml
 
       - name: Sync Cargo.lock
         if: ${{ steps.guard.outputs.is_release_commit != 'true' && steps.tag_check.outputs.tag_exists != 'true' && steps.semver.outputs.next_version != steps.semver.outputs.current_version }}


### PR DESCRIPTION
## Problem

Release #2 failed — the \`grep '^version = '\` pattern didn't match because \`Cargo.toml\` uses padded alignment spaces:

\`\`\`toml
version     = "0.1.0"   ← multiple spaces, not one
\`\`\`

## Fix

- **Read:** \`cargo metadata --no-deps\` + \`python3 -c\` (single-line, no heredoc) — authoritative and whitespace-agnostic
- **Write:** \`sed -i -E 's/^(version[[:space:]]*=[[:space:]]*")[0-9]+\\.[0-9]+\\.[0-9]+/\\1<next>/'\` — POSIX character class handles any spacing

## Test plan

- [ ] CI passes on this branch
- [ ] Re-trigger Release workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)