### PR TITLE
ci: serve docs/ as mdBook alongside cargo doc API reference

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,19 +35,28 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Build API docs
+      - name: Install mdBook
+        run: cargo install mdbook --locked
+
+      - name: Build docs (mdBook)
+        run: mdbook build docs/
+
+      - name: Build API docs (cargo doc)
         run: cargo doc --no-deps --locked
         env:
           RUSTDOCFLAGS: "--cfg docsrs"
 
-      - name: Add redirect index
+      - name: Assemble site
         run: |
-          echo '<meta http-equiv="refresh" content="0; url=trilink_core/index.html">' \
-            > target/doc/index.html
+          mkdir -p site/api
+          cp -r target/book/. site/
+          cp -r target/doc/. site/api/
+          # Root redirect → docs book
+          echo '<meta http-equiv="refresh" content="0; url=docs/">' > site/index.html
 
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:
-          path: target/doc/
+          path: site/
 
   deploy:
     needs: build

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,7 @@
+# Summary
+
+- [Architecture](architecture.md)
+- [Math Concepts](math.md)
+- [Known Limitations](limitations.md)
+- [Roadmap](roadmap.md)
+- [Contributing](contributing.md)

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,13 @@
+[book]
+title = "trilink-core"
+description = "Open-source core: pose buffer, unprojection math, and shared types for sensor-vision spatial fusion"
+authors = ["trilink-core contributors"]
+language = "en"
+src = "."
+
+[build]
+build-dir = "../target/book"
+
+[output.html]
+git-repository-url = "https://github.com/edgesentry/trilink-core"
+edit-url-template = "https://github.com/edgesentry/trilink-core/edit/main/docs/{path}"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -293,7 +293,6 @@ pub fn scan_delta(t0: &PointCloud, t1: &PointCloud, threshold_mm: f32) -> Deviat
 
 ---
 
-
 ### CP2 · IFC write-back data structures
 
 **Limitation:** L8 — AI detection results cannot be written back into an IFC 4.3 model as

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -363,4 +363,3 @@ The following are real problems but belong to a higher layer:
 | MLIT / CONQUAS equivalence documentation | commercial compliance layer |
 | Tamper-evidence / electronic signature | `edgesentry-audit` |
 | Multi-pose capture scheduling | sensor platform firmware |
-| 1D time-series inference (NEA/PUB water grid, NEA vibration monitoring) | Application inference layer; uses PatchTST/iTransformer on raw sensor streams — no spatial computation required |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -363,3 +363,4 @@ The following are real problems but belong to a higher layer:
 | MLIT / CONQUAS equivalence documentation | commercial compliance layer |
 | Tamper-evidence / electronic signature | `edgesentry-audit` |
 | Multi-pose capture scheduling | sensor platform firmware |
+| 1D time-series inference (NEA/PUB water grid, NEA vibration monitoring) | Application inference layer; uses PatchTST/iTransformer on raw sensor streams — no spatial computation required |


### PR DESCRIPTION
## Summary

- Add `docs/book.toml` and `docs/SUMMARY.md` to wire existing markdown files into an mdBook site
- Update `pages.yml` to build both mdBook and cargo doc, assembling into a single site:
  - `/` → redirects to `/docs/`
  - `/docs/` → mdBook (architecture, math, limitations, roadmap, contributing)
  - `/api/` → cargo doc API reference

## Why the docs weren't accessible

The `docs/` markdown files had no `book.toml` or `SUMMARY.md`, so mdBook couldn't build them. The previous workflow only published `cargo doc` output.

## Test plan

- [ ] Confirm Pages workflow builds without error
- [ ] Visit `https://edgesentry.github.io/trilink-core/` and verify redirect to `/docs/`
- [ ] Verify `/docs/` renders the mdBook with all five pages
- [ ] Verify `/api/trilink_core/index.html` loads the Rust API docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)