### PR TITLE
fix(ci): put mdBook output in site/docs/ so root redirect works

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Assemble site
         run: |
-          mkdir -p site/api
-          cp -r target/book/. site/
+          mkdir -p site/docs site/api
+          cp -r target/book/. site/docs/
           cp -r target/doc/. site/api/
           # Root redirect → docs book
           echo '<meta http-equiv="refresh" content="0; url=docs/">' > site/index.html


### PR DESCRIPTION
## Bug

The root `index.html` redirects to `docs/`, but `cp -r target/book/. site/` placed the mdBook content at `site/` root — so `site/docs/` never existed. Visitors hit a 404.

## Fix

Copy `target/book/` into `site/docs/` instead of `site/` root:

```
/              → redirect to /docs/
/docs/         → mdBook (architecture, math, limitations, roadmap, contributing)
/api/          → cargo doc API reference
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)