### PR TITLE
chore(deps): bump glam from 0.32.1 to 0.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "glam"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+checksum = "8fb167719045debebe9f532320accc7b5c993c5a3b813f5696a11d5ca7bdc57b"
 dependencies = [
  "serde_core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 [dependencies]
 serde      = { version = "1", features = ["derive"] }
 thiserror  = "2"
-glam       = { version = "0.32.1", features = ["serde"] }
+glam       = { version = "0.33", features = ["serde"] }
 
 [dev-dependencies]
 serde_json = "1"


### PR DESCRIPTION
## Summary

- Bump `glam` to 0.33 for serde feature compatibility with edgesentry-rs dependabot PR #412.

## Test plan

- [x] `cargo test` (78 unit + integration tests)

Required for merging [edgesentry-rs#412](https://github.com/edgesentry/edgesentry-rs/pull/412).

Made with [Cursor](https://cursor.com)