### PR TITLE
fix(ci): tolerate Windows cache post-step failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Cache Rust artifacts
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5
+        continue-on-error: true
         with:
           path: |
             ~/.cargo/bin/
@@ -108,6 +109,7 @@ jobs:
 
       - name: Cache Rust artifacts
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5
+        continue-on-error: true
         with:
           path: |
             ~/.cargo/bin/
@@ -146,6 +148,7 @@ jobs:
 
       - name: Cache Rust artifacts
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5
+        continue-on-error: true
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
## Summary

Fixes [CI run #115](https://github.com/edgesentry/trilink-core/actions/runs/26425822689) on `main` @ b8dada7.

**Root cause:** `Build and Test (windows-latest)` — all steps through `Run tests` succeeded; only **Post Cache Rust artifacts** failed (actions/cache tar/zstd upload on Windows Server 2025).

**Fix:** `continue-on-error: true` on `actions/cache` steps in `ci.yml` (cache is best-effort; compile/test results are authoritative).

## Test plan

- [ ] CI green on this PR (especially `windows-latest`)


Made with [Cursor](https://cursor.com)